### PR TITLE
 Rename batcher_key to batcher and partition to batch_key

### DIFF
--- a/lib/broadway/batch_info.ex
+++ b/lib/broadway/batch_info.ex
@@ -8,14 +8,12 @@ defmodule Broadway.BatchInfo do
   """
 
   @type t :: %__MODULE__{
-          batcher_key: atom,
-          batcher_pid: pid,
-          partition: term
+          batcher: atom,
+          batch_key: term
         }
 
   defstruct [
-    :batcher_key,
-    :batcher_pid,
-    :partition
+    :batcher,
+    :batch_key
   ]
 end

--- a/lib/broadway/batcher.ex
+++ b/lib/broadway/batcher.ex
@@ -13,17 +13,17 @@ defmodule Broadway.Batcher do
   @impl true
   def init(args) do
     Process.put(@all_batches, %{})
-    batcher_key = args[:batcher_key]
+    batcher = args[:batcher]
 
     state = %{
-      batcher_key: batcher_key,
+      batcher: batcher,
       batch_size: args[:batch_size],
       batch_timeout: args[:batch_timeout]
     }
 
     Broadway.Subscriber.init(
       args[:processors],
-      [partition: batcher_key, max_demand: args[:batch_size]],
+      [partition: batcher, max_demand: args[:batch_size]],
       state,
       args
     )
@@ -31,7 +31,7 @@ defmodule Broadway.Batcher do
 
   @impl true
   def handle_events(events, _from, state) do
-    batches = handle_events_per_partition(events, [], state)
+    batches = handle_events_per_batch_key(events, [], state)
     {:noreply, batches, state}
   end
 
@@ -74,32 +74,32 @@ defmodule Broadway.Batcher do
 
   ## Default batch handling
 
-  defp handle_events_per_partition([], acc, _state) do
+  defp handle_events_per_batch_key([], acc, _state) do
     Enum.reverse(acc)
   end
 
-  defp handle_events_per_partition([%{partition: partition} | _] = events, acc, state) do
-    {current, pending_count, timer} = init_or_get_batch(partition, state)
-    {current, pending_count, events} = split_counting(partition, events, pending_count, current)
+  defp handle_events_per_batch_key([%{batch_key: batch_key} | _] = events, acc, state) do
+    {current, pending_count, timer} = init_or_get_batch(batch_key, state)
+    {current, pending_count, events} = split_counting(batch_key, events, pending_count, current)
 
-    acc = deliver_or_update_batch(partition, current, pending_count, timer, acc, state)
-    handle_events_per_partition(events, acc, state)
+    acc = deliver_or_update_batch(batch_key, current, pending_count, timer, acc, state)
+    handle_events_per_batch_key(events, acc, state)
   end
 
-  defp split_counting(partition, [%{partition: partition} = event | events], count, acc)
+  defp split_counting(batch_key, [%{batch_key: batch_key} = event | events], count, acc)
        when count > 0,
        do: split_counting(events, count - 1, [event | acc])
 
   defp split_counting(events, count, acc), do: {acc, count, events}
 
-  defp deliver_or_update_batch(partition, current, 0, timer, acc, state) do
-    delete_batch(partition)
+  defp deliver_or_update_batch(batch_key, current, 0, timer, acc, state) do
+    delete_batch(batch_key)
     cancel_batch_timeout(timer)
-    [wrap_for_delivery(partition, current, state) | acc]
+    [wrap_for_delivery(batch_key, current, state) | acc]
   end
 
-  defp deliver_or_update_batch(partition, current, pending_count, timer, acc, _state) do
-    put_batch(partition, {current, pending_count, timer})
+  defp deliver_or_update_batch(batch_key, current, pending_count, timer, acc, _state) do
+    put_batch(batch_key, {current, pending_count, timer})
     acc
   end
 
@@ -158,13 +158,12 @@ defmodule Broadway.Batcher do
     end
   end
 
-  defp wrap_for_delivery(partition, reversed_events, state) do
-    %{batcher_key: batcher_key} = state
+  defp wrap_for_delivery(batch_key, reversed_events, state) do
+    %{batcher: batcher} = state
 
     batch_info = %BatchInfo{
-      batcher_key: batcher_key,
-      batcher_pid: self(),
-      partition: partition
+      batcher: batcher,
+      batch_key: batch_key
     }
 
     {Enum.reverse(reversed_events), batch_info}

--- a/lib/broadway/consumer.ex
+++ b/lib/broadway/consumer.ex
@@ -32,8 +32,7 @@ defmodule Broadway.Consumer do
     [{messages, batch_info}] = events
     %Broadway.BatchInfo{batcher: batcher} = batch_info
 
-    {successful_messages, failed_messages} =
-      handle_batch(batcher, messages, batch_info, state)
+    {successful_messages, failed_messages} = handle_batch(batcher, messages, batch_info, state)
 
     try do
       Acknowledger.ack_messages(successful_messages, failed_messages)

--- a/lib/broadway/consumer.ex
+++ b/lib/broadway/consumer.ex
@@ -30,10 +30,10 @@ defmodule Broadway.Consumer do
   @impl true
   def handle_events(events, _from, state) do
     [{messages, batch_info}] = events
-    %Broadway.BatchInfo{batcher_key: batcher_key} = batch_info
+    %Broadway.BatchInfo{batcher: batcher} = batch_info
 
     {successful_messages, failed_messages} =
-      handle_batch(batcher_key, messages, batch_info, state)
+      handle_batch(batcher, messages, batch_info, state)
 
     try do
       Acknowledger.ack_messages(successful_messages, failed_messages)
@@ -45,11 +45,11 @@ defmodule Broadway.Consumer do
     {:noreply, [], state}
   end
 
-  defp handle_batch(batcher_key, messages, batch_info, state) do
+  defp handle_batch(batcher, messages, batch_info, state) do
     %{module: module, context: context} = state
 
     try do
-      module.handle_batch(batcher_key, messages, batch_info, context)
+      module.handle_batch(batcher, messages, batch_info, context)
       |> Enum.split_with(fn %Message{status: status} -> status == :ok end)
     catch
       kind, reason ->

--- a/lib/broadway/message.ex
+++ b/lib/broadway/message.ex
@@ -18,7 +18,7 @@ defmodule Broadway.Message do
           data: any,
           acknowledger: {module, ack_ref :: any, data :: any},
           batcher: atom,
-          partition: term,
+          batch_key: term,
           status: :ok | {:failed, reason :: binary}
         }
 
@@ -26,7 +26,7 @@ defmodule Broadway.Message do
   defstruct data: nil,
             acknowledger: nil,
             batcher: :default,
-            partition: :default,
+            batch_key: :default,
             status: :ok
 
   @doc """
@@ -49,11 +49,14 @@ defmodule Broadway.Message do
   end
 
   @doc """
-  Defines the partition within a batcher for the message.
+  Defines the batch key within a batcher for the message.
+
+  Inside each batcher, we attempt to build `batch_size`
+  within `batch_timeout` for each `batch_key`.
   """
-  @spec put_partition(message :: Message.t(), partition :: term) :: Message.t()
-  def put_partition(%Message{} = message, partition) do
-    %Message{message | partition: partition}
+  @spec put_batch_key(message :: Message.t(), batch_key :: term) :: Message.t()
+  def put_batch_key(%Message{} = message, batch_key) do
+    %Message{message | batch_key: batch_key}
   end
 
   @doc """

--- a/lib/broadway/server.ex
+++ b/lib/broadway/server.ex
@@ -211,7 +211,7 @@ defmodule Broadway.Server do
         type: :producer_consumer,
         resubscribe: :never,
         terminator: terminator,
-        batcher_key: key,
+        batcher: key,
         processors: processors
       ] ++ options
 

--- a/test/broadway/batcher_test.exs
+++ b/test/broadway/batcher_test.exs
@@ -9,7 +9,7 @@ defmodule Broadway.BatcherTest do
         type: :producer_consumer,
         terminator: __MODULE__,
         resubscribe: :never,
-        batcher_key: :default,
+        batcher: :default,
         processors: [:some_processor],
         batch_size: 123,
         batch_timeout: 1000


### PR DESCRIPTION
Because we may have mutiple partitions along the way,
it is probably best to distance ourselves from the
"partition" name. Instead, `batch_key` is used, as it
is one of the factor for specifying a batch beyond the
batch_size and batch_timeout.

To avoid  confusion, batcher_key in `%BatchInfo{}` was
rename to batcher (to mirror `put_batcher`) and `batcher_pid`
was removed for now.