### PR TITLE
Allow producers to be canceled for shutdown

### DIFF
--- a/lib/broadway/producer.ex
+++ b/lib/broadway/producer.ex
@@ -3,6 +3,9 @@ defmodule Broadway.Producer do
   use GenStage
   alias Broadway.Message
 
+  @callback prepare_for_draining(state :: any) :: any
+  @optional_callbacks prepare_for_draining: 1
+
   @spec start_link(term, GenServer.options()) :: GenServer.on_start()
   def start_link(args, opts \\ []) do
     GenStage.start_link(__MODULE__, args, opts)
@@ -66,11 +69,11 @@ defmodule Broadway.Producer do
   end
 
   @impl true
-  def handle_cast(:cancel_producer, state) do
+  def handle_cast(:prepare_for_draining, state) do
     %{module: module, module_state: module_state} = state
 
-    if function_exported?(module, :cancel, 1) do
-      module.cancel(module_state)
+    if function_exported?(module, :prepare_for_draining, 1) do
+      module.prepare_for_draining(module_state)
     end
 
     {:noreply, [], state}

--- a/lib/broadway/terminator.ex
+++ b/lib/broadway/terminator.ex
@@ -41,6 +41,7 @@ defmodule Broadway.Terminator do
     end
 
     for name <- state.producers, pid = Process.whereis(name) do
+      GenStage.cast(pid, :cancel_producer)
       GenStage.demand(pid, :accumulate)
       GenStage.async_info(pid, :cancel_consumers)
     end

--- a/lib/broadway/terminator.ex
+++ b/lib/broadway/terminator.ex
@@ -41,7 +41,7 @@ defmodule Broadway.Terminator do
     end
 
     for name <- state.producers, pid = Process.whereis(name) do
-      GenStage.cast(pid, :cancel_producer)
+      GenStage.cast(pid, :prepare_for_draining)
       GenStage.demand(pid, :accumulate)
       GenStage.async_info(pid, :cancel_consumers)
     end

--- a/test/broadway/producer_test.exs
+++ b/test/broadway/producer_test.exs
@@ -59,8 +59,19 @@ defmodule Broadway.ProducerTest do
     def init(_), do: {:producer, nil}
   end
 
+  defmodule ProducerWithBadReturn do
+    use GenStage
+
+    def init(_), do: {:consumer, nil}
+  end
+
   setup do
     %{state: %{module: FakeProducer, transformer: nil, module_state: nil}}
+  end
+
+  test "init with bad return" do
+    args = %{module: {ProducerWithBadReturn, []}}
+    assert Producer.init(args) == {:stop, {:bad_return_value, {:consumer, nil}}}
   end
 
   describe "wrap handle_demand" do

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -26,6 +26,8 @@ defmodule BroadwayTest do
   defmodule ManualProducer do
     use GenStage
 
+    @behaviour Broadway.Producer
+
     def start_link(args, opts \\ []) do
       GenStage.start_link(__MODULE__, args, opts)
     end
@@ -36,19 +38,23 @@ defmodule BroadwayTest do
       {:producer, %{test_pid: test_pid}}
     end
 
+    @impl true
     def init(_args) do
       {:producer, %{}}
     end
 
+    @impl true
     def handle_demand(_demand, state) do
       {:noreply, [], state}
     end
 
+    @impl true
     def handle_info({:push_messages_async, messages}, state) do
       {:noreply, messages, state}
     end
 
-    def cancel(%{test_pid: test_pid}) do
+    @impl true
+    def prepare_for_draining(%{test_pid: test_pid}) do
       message = wrap_message(:message_during_cancel, test_pid)
       send(self(), {:push_messages_async, [message]})
 
@@ -57,7 +63,8 @@ defmodule BroadwayTest do
       :ok
     end
 
-    def cancel(_state) do
+    @impl true
+    def prepare_for_draining(_state) do
       :ok
     end
 


### PR DESCRIPTION
This is required for active producers like `BroadwayRabbitmq.Producer`