### PR TITLE
Avoids name conflict in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ defmodule MyBroadway do
 
   def start_link(_opts) do
     Broadway.start_link(__MODULE__,
-      name: __MODULE__,
+      name: Module.concat(__MODULE__, "Example"),
       producers: [
         sqs: [
           module: {BroadwaySQS.Producer, queue_name: "my_queue"}


### PR DESCRIPTION
When `__MODULE__` is used twice, it causes the exception `** (MatchError) no match of right hand side value: {:error, {:already_started, #PID<0.213.0>}}`