### PR TITLE
Optimise batcher for subsequent events with the same batch key

### DIFF
--- a/lib/broadway/batcher.ex
+++ b/lib/broadway/batcher.ex
@@ -89,9 +89,9 @@ defmodule Broadway.Batcher do
 
   defp split_counting(batch_key, [%{batch_key: batch_key} = event | events], count, acc)
        when count > 0,
-       do: split_counting(events, count - 1, [event | acc])
+       do: split_counting(batch_key, events, count - 1, [event | acc])
 
-  defp split_counting(events, count, acc), do: {acc, count, events}
+  defp split_counting(_batch_key, events, count, acc), do: {acc, count, events}
 
   defp deliver_or_update_batch(batch_key, current, 0, timer, acc, state) do
     delete_batch(batch_key)


### PR DESCRIPTION
While reviewing the code I noticed that the the `split_counting` clauses had
different arities. There's also a guard on the first one which made it
suspicious. I thought that there might be a case when this would lead to
a `FunctionClauseError`.

It turns out that the guard will always return with true because `batch_size`
must be a positive number and `split_counting` is not really recursive. It
always passes back control to `handle_events_per_batch_key` which will let
`deliver_or_update_batch` handle the `count = 0` case.

This also means that there is some room for optimisation here because currently
we're calling `put_batch` after each event even if there are more events with
the same batch key and there is room in the batch for more events.

I haven't tested the performance benefits. I don't expect this to be a huge
improvement. Even that would only be realised with a single or limited number of
batchers. The point is mostly to make `split_counting` behave the way one would
expect it to.