### PR TITLE
Add `:batch_mode` and default to `:flush` for test messages

### DIFF
--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -302,7 +302,7 @@ defmodule Broadway do
   its size or its timeout has been reached, but that is often impractical
   for testing, you may not necessarily want to send a lot of data or
   wait a lot of time for the batch to flush. For this reason, when using
-  `test_messages/2`, by default the messages have their `:batching_mode`
+  `test_messages/2`, by default the messages have their `:batch_mode`
   set to `:flush` which means the batch will be immediately delivered.
   Depending on the batch size and the batching mode you might get multiple
   acknowledgment messages. For example, if the batcher in the example above
@@ -542,7 +542,7 @@ defmodule Broadway do
 
   ## Options
 
-  * `:batching_mode` - when set to `:flush`, the batch the message is
+  * `:batch_mode` - when set to `:flush`, the batch the message is
     in is immediately delivered. When set to `:bulk`, batch is
     delivered when its size or timeout is reached. Defaults to `:flush`.
 
@@ -558,12 +558,11 @@ defmodule Broadway do
   """
   @spec test_messages(GenServer.server(), data :: [term]) :: reference
   def test_messages(broadway, data, opts \\ []) when is_list(data) and is_list(opts) do
-    batching_mode = Keyword.get(opts, :batching_mode, :flush)
+    batch_mode = Keyword.get(opts, :batch_mode, :flush)
     ref = make_ref()
     ack = {Broadway.CallerAcknowledger, {self(), ref}, :ok}
 
-    messages =
-      Enum.map(data, &%Message{data: &1, acknowledger: ack, batching_mode: batching_mode})
+    messages = Enum.map(data, &%Message{data: &1, acknowledger: ack, batch_mode: batch_mode})
 
     :ok = push_messages(broadway, messages)
     ref

--- a/lib/broadway/batcher.ex
+++ b/lib/broadway/batcher.ex
@@ -83,7 +83,8 @@ defmodule Broadway.Batcher do
     {current, pending_count, timer} = init_or_get_batch(batch_key, state)
     {current, pending_count, events} = split_counting(batch_key, events, pending_count, current)
 
-    acc = deliver_or_update_batch(batch_key, current, pending_count, timer, acc, state)
+    flush? = Enum.any?(current, &(&1.batching_mode == :flush))
+    acc = deliver_or_update_batch(batch_key, current, pending_count, flush?, timer, acc, state)
     handle_events_per_batch_key(events, acc, state)
   end
 
@@ -93,15 +94,23 @@ defmodule Broadway.Batcher do
 
   defp split_counting(_batch_key, events, count, acc), do: {acc, count, events}
 
-  defp deliver_or_update_batch(batch_key, current, 0, timer, acc, state) do
+  defp deliver_or_update_batch(batch_key, current, _pending_count, true, timer, acc, state) do
+    deliver_batch(batch_key, current, timer, acc, state)
+  end
+
+  defp deliver_or_update_batch(batch_key, current, 0, _flush?, timer, acc, state) do
+    deliver_batch(batch_key, current, timer, acc, state)
+  end
+
+  defp deliver_or_update_batch(batch_key, current, pending_count, _flush?, timer, acc, _state) do
+    put_batch(batch_key, {current, pending_count, timer})
+    acc
+  end
+
+  defp deliver_batch(batch_key, current, timer, acc, state) do
     delete_batch(batch_key)
     cancel_batch_timeout(timer)
     [wrap_for_delivery(batch_key, current, state) | acc]
-  end
-
-  defp deliver_or_update_batch(batch_key, current, pending_count, timer, acc, _state) do
-    put_batch(batch_key, {current, pending_count, timer})
-    acc
   end
 
   ## General batch handling

--- a/lib/broadway/batcher.ex
+++ b/lib/broadway/batcher.ex
@@ -91,7 +91,7 @@ defmodule Broadway.Batcher do
 
   defp split_counting(batch_key, [%{batch_key: batch_key} = event | events], count, flush?, acc)
        when count > 0 do
-    flush? = flush? || event.batch_mode == :flush
+    flush? = flush? or event.batch_mode == :flush
     split_counting(batch_key, events, count - 1, flush?, [event | acc])
   end
 

--- a/lib/broadway/batcher.ex
+++ b/lib/broadway/batcher.ex
@@ -83,7 +83,7 @@ defmodule Broadway.Batcher do
     {current, pending_count, timer} = init_or_get_batch(batch_key, state)
     {current, pending_count, events} = split_counting(batch_key, events, pending_count, current)
 
-    flush? = Enum.any?(current, &(&1.batching_mode == :flush))
+    flush? = Enum.any?(current, &(&1.batch_mode == :flush))
     acc = deliver_or_update_batch(batch_key, current, pending_count, flush?, timer, acc, state)
     handle_events_per_batch_key(events, acc, state)
   end

--- a/lib/broadway/message.ex
+++ b/lib/broadway/message.ex
@@ -20,7 +20,7 @@ defmodule Broadway.Message do
           acknowledger: {module, ack_ref :: term, data :: term},
           batcher: atom,
           batch_key: term,
-          batching_mode: :bulk | :flush,
+          batch_mode: :bulk | :flush,
           status: :ok | {:failed, reason :: binary}
         }
 
@@ -30,7 +30,7 @@ defmodule Broadway.Message do
             acknowledger: nil,
             batcher: :default,
             batch_key: :default,
-            batching_mode: :bulk,
+            batch_mode: :bulk,
             status: :ok
 
   @doc """
@@ -74,9 +74,9 @@ defmodule Broadway.Message do
 
   The default mode for messages is `:bulk`.
   """
-  @spec put_batching_mode(message :: Message.t(), mode :: :bulk | :flush) :: Message.t()
-  def put_batching_mode(%Message{} = message, mode) when mode in [:bulk, :flush] do
-    %Message{message | batching_mode: mode}
+  @spec put_batch_mode(message :: Message.t(), mode :: :bulk | :flush) :: Message.t()
+  def put_batch_mode(%Message{} = message, mode) when mode in [:bulk, :flush] do
+    %Message{message | batch_mode: mode}
   end
 
   @doc """

--- a/lib/broadway/message.ex
+++ b/lib/broadway/message.ex
@@ -20,6 +20,7 @@ defmodule Broadway.Message do
           acknowledger: {module, ack_ref :: term, data :: term},
           batcher: atom,
           batch_key: term,
+          batching_mode: :bulk | :flush,
           status: :ok | {:failed, reason :: binary}
         }
 
@@ -29,6 +30,7 @@ defmodule Broadway.Message do
             acknowledger: nil,
             batcher: :default,
             batch_key: :default,
+            batching_mode: :bulk,
             status: :ok
 
   @doc """
@@ -59,6 +61,22 @@ defmodule Broadway.Message do
   @spec put_batch_key(message :: Message.t(), batch_key :: term) :: Message.t()
   def put_batch_key(%Message{} = message, batch_key) do
     %Message{message | batch_key: batch_key}
+  end
+
+  @doc """
+  Sets the batching mode for the message.
+
+  When the mode is `:bulk`, the batch that the message is in is delivered after
+  the batch size or the batch timeout is reached.
+
+  When the mode is `:flush`, the batch that the message is in is delivered
+  immediately.
+
+  The default mode for messages is `:bulk`.
+  """
+  @spec put_batching_mode(message :: Message.t(), mode :: :bulk | :flush) :: Message.t()
+  def put_batching_mode(%Message{} = message, mode) when mode in [:bulk, :flush] do
+    %Message{message | batching_mode: mode}
   end
 
   @doc """

--- a/lib/broadway/message.ex
+++ b/lib/broadway/message.ex
@@ -70,7 +70,8 @@ defmodule Broadway.Message do
   the batch size or the batch timeout is reached.
 
   When the mode is `:flush`, the batch that the message is in is delivered
-  immediately.
+  immediately after processing. Note it doesn't mean the batch contains only a single element
+  but rather that all messages receives from the processor are delivered without waiting.
 
   The default mode for messages is `:bulk`.
   """

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -353,7 +353,7 @@ defmodule BroadwayTest do
     end
 
     test "successful messages are marked as :ok", %{broadway: broadway} do
-      ref = Broadway.test_messages(broadway, [1, 2], batching_mode: :bulk)
+      ref = Broadway.test_messages(broadway, [1, 2], batch_mode: :bulk)
       assert_receive {:batch_handled, [%{status: :ok}, %{status: :ok}]}
       assert_receive {:ack, ^ref, [%{status: :ok}, %{status: :ok}], []}
     end
@@ -364,7 +364,7 @@ defmodule BroadwayTest do
     end
 
     test "failed messages are not forwarded to the batcher", %{broadway: broadway} do
-      ref = Broadway.test_messages(broadway, [1, :fail, :fail, 4], batching_mode: :bulk)
+      ref = Broadway.test_messages(broadway, [1, :fail, :fail, 4], batch_mode: :bulk)
 
       assert_receive {:batch_handled, [%{data: 1}, %{data: 4}]}
       assert_receive {:ack, ^ref, [%{status: :ok}, %{status: :ok}], []}
@@ -375,7 +375,7 @@ defmodule BroadwayTest do
     test "messages are marked as {:failed, reason} when an error is raised while processing",
          %{broadway: broadway, processor: processor} do
       assert capture_log(fn ->
-               ref = Broadway.test_messages(broadway, [1, :raise, 4], batching_mode: :bulk)
+               ref = Broadway.test_messages(broadway, [1, :raise, 4], batch_mode: :bulk)
 
                assert_receive {:ack, ^ref, [],
                                [%{status: {:failed, "due to an unhandled error"}}]}
@@ -389,7 +389,7 @@ defmodule BroadwayTest do
     test "messages are marked as {:failed, reason} on bad return",
          %{broadway: broadway, processor: processor} do
       assert capture_log(fn ->
-               ref = Broadway.test_messages(broadway, [1, :bad_return, 4], batching_mode: :bulk)
+               ref = Broadway.test_messages(broadway, [1, :bad_return, 4], batch_mode: :bulk)
 
                assert_receive {:ack, ^ref, [],
                                [%{status: {:failed, "due to an unhandled error"}}]}
@@ -404,7 +404,7 @@ defmodule BroadwayTest do
     test "messages are marked as {:failed, reason} on bad batcher",
          %{broadway: broadway, processor: processor} do
       assert capture_log(fn ->
-               ref = Broadway.test_messages(broadway, [1, :bad_batcher, 4], batching_mode: :bulk)
+               ref = Broadway.test_messages(broadway, [1, :bad_batcher, 4], batch_mode: :bulk)
 
                assert_receive {:ack, ^ref, [],
                                [%{status: {:failed, "due to an unhandled error"}}]}
@@ -431,7 +431,7 @@ defmodule BroadwayTest do
 
     test "processors do not crash on broken link", %{broadway: broadway, processor: processor} do
       assert capture_log(fn ->
-               ref = Broadway.test_messages(broadway, [1, :broken_link, 4], batching_mode: :bulk)
+               ref = Broadway.test_messages(broadway, [1, :broken_link, 4], batch_mode: :bulk)
 
                assert_receive {:ack, ^ref, [], [%{status: {:failed, "due to an unhandled exit"}}]}
 
@@ -541,7 +541,7 @@ defmodule BroadwayTest do
     end
 
     test "generate batches based on :batch_size", %{broadway: broadway} do
-      Broadway.test_messages(broadway, Enum.to_list(1..40), batching_mode: :bulk)
+      Broadway.test_messages(broadway, Enum.to_list(1..40), batch_mode: :bulk)
 
       assert_receive {:batch_handled, :odd, messages, %BatchInfo{batcher: :odd}}
                      when length(messages) == 10
@@ -608,7 +608,7 @@ defmodule BroadwayTest do
     end
 
     test "generate batches based on :batch_size", %{broadway: broadway} do
-      ref = Broadway.test_messages(broadway, Enum.to_list(1..10), batching_mode: :bulk)
+      ref = Broadway.test_messages(broadway, Enum.to_list(1..10), batch_mode: :bulk)
 
       assert_receive {:ack, ^ref, [%{data: 1, batch_key: :odd}, %{data: 3, batch_key: :odd}], []}
 
@@ -628,7 +628,7 @@ defmodule BroadwayTest do
     end
   end
 
-  describe "put_batching_mode" do
+  describe "put_batch_mode" do
     setup do
       test_pid = self()
       broadway_name = new_unique_name()
@@ -672,7 +672,7 @@ defmodule BroadwayTest do
     end
 
     test "bulk", %{broadway: broadway} do
-      ref = Broadway.test_messages(broadway, [1, 2, 3, 4, 5], batching_mode: :bulk)
+      ref = Broadway.test_messages(broadway, [1, 2, 3, 4, 5], batch_mode: :bulk)
       assert_receive {:batch_handled, :default, _}
       assert_receive {:ack, ^ref, [%{data: 1}, %{data: 2}], []}
       assert_receive {:batch_handled, :default, _}
@@ -886,7 +886,7 @@ defmodule BroadwayTest do
     end
 
     test "only the messages in the crashing processor are lost", %{broadway: broadway} do
-      Broadway.test_messages(broadway, [1, 2, :kill_processor, 3, 4, 5], batching_mode: :bulk)
+      Broadway.test_messages(broadway, [1, 2, :kill_processor, 3, 4, 5], batch_mode: :bulk)
 
       assert_receive {:message_handled, %{data: 1}}
       assert_receive {:message_handled, %{data: 2}}
@@ -899,7 +899,7 @@ defmodule BroadwayTest do
     end
 
     test "batches are created normally (without the lost messages)", %{broadway: broadway} do
-      Broadway.test_messages(broadway, [1, 2, :kill_processor, 3, 4, 5], batching_mode: :bulk)
+      Broadway.test_messages(broadway, [1, 2, :kill_processor, 3, 4, 5], batch_mode: :bulk)
 
       assert_receive {:batch_handled, messages}
       values = messages |> Enum.map(& &1.data)
@@ -958,15 +958,15 @@ defmodule BroadwayTest do
     end
 
     test "batcher will be restarted in order to handle other messages", %{broadway: broadway} do
-      Broadway.test_messages(broadway, [1, 2], batching_mode: :bulk)
+      Broadway.test_messages(broadway, [1, 2], batch_mode: :bulk)
       assert_receive {:batch_handled, _, batcher1} when is_pid(batcher1)
       ref = Process.monitor(batcher1)
 
-      Broadway.test_messages(broadway, [:kill_batcher, 3], batching_mode: :bulk)
+      Broadway.test_messages(broadway, [:kill_batcher, 3], batch_mode: :bulk)
       assert_receive {:batch_handled, _, ^batcher1}
       assert_receive {:DOWN, ^ref, _, _, _}
 
-      Broadway.test_messages(broadway, [4, 5], batching_mode: :bulk)
+      Broadway.test_messages(broadway, [4, 5], batch_mode: :bulk)
       assert_receive {:batch_handled, _, batcher2} when is_pid(batcher2)
       assert batcher1 != batcher2
     end
@@ -994,9 +994,7 @@ defmodule BroadwayTest do
 
     test "only the messages in the crashing batcher are lost", %{broadway: broadway} do
       ref =
-        Broadway.test_messages(broadway, [1, 2, :kill_batcher, 3, 4, 5, 6, 7],
-          batching_mode: :bulk
-        )
+        Broadway.test_messages(broadway, [1, 2, :kill_batcher, 3, 4, 5, 6, 7], batch_mode: :bulk)
 
       assert_receive {:ack, ^ref, successful, _failed}
       values = Enum.map(successful, & &1.data)
@@ -1071,7 +1069,7 @@ defmodule BroadwayTest do
     test "all messages in the batch are marked as {:failed, reason} when an error is raised",
          %{broadway: broadway, consumer: consumer} do
       assert capture_log(fn ->
-               ref = Broadway.test_messages(broadway, [1, 2, :raise, 3], batching_mode: :bulk)
+               ref = Broadway.test_messages(broadway, [1, 2, :raise, 3], batch_mode: :bulk)
 
                assert_receive {:ack, ^ref, [],
                                [
@@ -1088,8 +1086,7 @@ defmodule BroadwayTest do
     test "all messages in the batch are marked as {:failed, reason} on bad return",
          %{broadway: broadway, consumer: consumer} do
       assert capture_log(fn ->
-               ref =
-                 Broadway.test_messages(broadway, [1, 2, :bad_return, 3], batching_mode: :bulk)
+               ref = Broadway.test_messages(broadway, [1, 2, :bad_return, 3], batch_mode: :bulk)
 
                assert_receive {:ack, ^ref, [],
                                [
@@ -1113,7 +1110,7 @@ defmodule BroadwayTest do
 
       assert capture_log(fn ->
                Broadway.push_messages(broadway, [one, two, raise, three])
-               ref = Broadway.test_messages(broadway, [1, 2, 3, 4], batching_mode: :bulk)
+               ref = Broadway.test_messages(broadway, [1, 2, 3, 4], batch_mode: :bulk)
                assert_receive {:ack, ^ref, [%{data: 1}, %{data: 2}, %{data: 3}, %{data: 4}], []}
              end) =~ "[error] ** (UndefinedFunctionError) function Unknown.ack/3 is undefined"
 
@@ -1123,8 +1120,7 @@ defmodule BroadwayTest do
     test "consumers do not crash on broken link",
          %{broadway: broadway, consumer: consumer} do
       assert capture_log(fn ->
-               ref =
-                 Broadway.test_messages(broadway, [1, 2, :broken_link, 3], batching_mode: :bulk)
+               ref = Broadway.test_messages(broadway, [1, 2, :broken_link, 3], batch_mode: :bulk)
 
                assert_receive {:ack, ^ref, [],
                                [
@@ -1201,7 +1197,7 @@ defmodule BroadwayTest do
 
     test "shutting down broadway waits until all events are processed even on incomplete batches",
          %{broadway: broadway} do
-      ref = Broadway.test_messages(broadway, [1, 2], batching_mode: :bulk)
+      ref = Broadway.test_messages(broadway, [1, 2], batch_mode: :bulk)
       Process.exit(broadway, :shutdown)
       assert_receive {:ack, ^ref, [%{data: 1}, %{data: 2}], []}
     end

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -353,7 +353,7 @@ defmodule BroadwayTest do
     end
 
     test "successful messages are marked as :ok", %{broadway: broadway} do
-      ref = Broadway.test_messages(broadway, [1, 2])
+      ref = Broadway.test_messages(broadway, [1, 2], batching_mode: :bulk)
       assert_receive {:batch_handled, [%{status: :ok}, %{status: :ok}]}
       assert_receive {:ack, ^ref, [%{status: :ok}, %{status: :ok}], []}
     end
@@ -364,7 +364,7 @@ defmodule BroadwayTest do
     end
 
     test "failed messages are not forwarded to the batcher", %{broadway: broadway} do
-      ref = Broadway.test_messages(broadway, [1, :fail, :fail, 4])
+      ref = Broadway.test_messages(broadway, [1, :fail, :fail, 4], batching_mode: :bulk)
 
       assert_receive {:batch_handled, [%{data: 1}, %{data: 4}]}
       assert_receive {:ack, ^ref, [%{status: :ok}, %{status: :ok}], []}
@@ -375,7 +375,7 @@ defmodule BroadwayTest do
     test "messages are marked as {:failed, reason} when an error is raised while processing",
          %{broadway: broadway, processor: processor} do
       assert capture_log(fn ->
-               ref = Broadway.test_messages(broadway, [1, :raise, 4])
+               ref = Broadway.test_messages(broadway, [1, :raise, 4], batching_mode: :bulk)
 
                assert_receive {:ack, ^ref, [],
                                [%{status: {:failed, "due to an unhandled error"}}]}
@@ -389,7 +389,7 @@ defmodule BroadwayTest do
     test "messages are marked as {:failed, reason} on bad return",
          %{broadway: broadway, processor: processor} do
       assert capture_log(fn ->
-               ref = Broadway.test_messages(broadway, [1, :bad_return, 4])
+               ref = Broadway.test_messages(broadway, [1, :bad_return, 4], batching_mode: :bulk)
 
                assert_receive {:ack, ^ref, [],
                                [%{status: {:failed, "due to an unhandled error"}}]}
@@ -404,7 +404,7 @@ defmodule BroadwayTest do
     test "messages are marked as {:failed, reason} on bad batcher",
          %{broadway: broadway, processor: processor} do
       assert capture_log(fn ->
-               ref = Broadway.test_messages(broadway, [1, :bad_batcher, 4])
+               ref = Broadway.test_messages(broadway, [1, :bad_batcher, 4], batching_mode: :bulk)
 
                assert_receive {:ack, ^ref, [],
                                [%{status: {:failed, "due to an unhandled error"}}]}
@@ -431,7 +431,7 @@ defmodule BroadwayTest do
 
     test "processors do not crash on broken link", %{broadway: broadway, processor: processor} do
       assert capture_log(fn ->
-               ref = Broadway.test_messages(broadway, [1, :broken_link, 4])
+               ref = Broadway.test_messages(broadway, [1, :broken_link, 4], batching_mode: :bulk)
 
                assert_receive {:ack, ^ref, [], [%{status: {:failed, "due to an unhandled exit"}}]}
 
@@ -541,7 +541,7 @@ defmodule BroadwayTest do
     end
 
     test "generate batches based on :batch_size", %{broadway: broadway} do
-      Broadway.test_messages(broadway, Enum.to_list(1..40))
+      Broadway.test_messages(broadway, Enum.to_list(1..40), batching_mode: :bulk)
 
       assert_receive {:batch_handled, :odd, messages, %BatchInfo{batcher: :odd}}
                      when length(messages) == 10
@@ -608,7 +608,7 @@ defmodule BroadwayTest do
     end
 
     test "generate batches based on :batch_size", %{broadway: broadway} do
-      ref = Broadway.test_messages(broadway, Enum.to_list(1..10))
+      ref = Broadway.test_messages(broadway, Enum.to_list(1..10), batching_mode: :bulk)
 
       assert_receive {:ack, ^ref, [%{data: 1, batch_key: :odd}, %{data: 3, batch_key: :odd}], []}
 
@@ -625,6 +625,60 @@ defmodule BroadwayTest do
 
       assert_receive {:ack, ^ref, [%{data: 1, batch_key: :odd}], []}
       assert_receive {:ack, ^ref, [%{data: 2, batch_key: :even}], []}
+    end
+  end
+
+  describe "put_batching_mode" do
+    setup do
+      test_pid = self()
+      broadway_name = new_unique_name()
+
+      handle_message = fn message, _ ->
+        message
+      end
+
+      context = %{
+        handle_message: handle_message,
+        handle_batch: fn batcher, batch, batch_info, _ ->
+          send(test_pid, {:batch_handled, batcher, batch_info})
+          batch
+        end
+      }
+
+      {:ok, broadway} =
+        Broadway.start_link(CustomHandlers,
+          name: broadway_name,
+          context: context,
+          producers: [default: [module: {ManualProducer, []}]],
+          processors: [default: []],
+          batchers: [default: [batch_size: 2, batch_timeout: 20]]
+        )
+
+      %{broadway: broadway}
+    end
+
+    test "flush by default", %{broadway: broadway} do
+      ref = Broadway.test_messages(broadway, [1, 2, 3, 4, 5])
+      assert_receive {:batch_handled, :default, _}
+      assert_receive {:ack, ^ref, [%{data: 1}], []}
+      assert_receive {:batch_handled, :default, _}
+      assert_receive {:ack, ^ref, [%{data: 2}], []}
+      assert_receive {:batch_handled, :default, _}
+      assert_receive {:ack, ^ref, [%{data: 3}], []}
+      assert_receive {:batch_handled, :default, _}
+      assert_receive {:ack, ^ref, [%{data: 4}], []}
+      assert_receive {:batch_handled, :default, _}
+      assert_receive {:ack, ^ref, [%{data: 5}], []}
+    end
+
+    test "bulk", %{broadway: broadway} do
+      ref = Broadway.test_messages(broadway, [1, 2, 3, 4, 5], batching_mode: :bulk)
+      assert_receive {:batch_handled, :default, _}
+      assert_receive {:ack, ^ref, [%{data: 1}, %{data: 2}], []}
+      assert_receive {:batch_handled, :default, _}
+      assert_receive {:ack, ^ref, [%{data: 3}, %{data: 4}], []}
+      assert_receive {:batch_handled, :default, _}
+      assert_receive {:ack, ^ref, [%{data: 5}], []}
     end
   end
 
@@ -832,7 +886,7 @@ defmodule BroadwayTest do
     end
 
     test "only the messages in the crashing processor are lost", %{broadway: broadway} do
-      Broadway.test_messages(broadway, [1, 2, :kill_processor, 3, 4, 5])
+      Broadway.test_messages(broadway, [1, 2, :kill_processor, 3, 4, 5], batching_mode: :bulk)
 
       assert_receive {:message_handled, %{data: 1}}
       assert_receive {:message_handled, %{data: 2}}
@@ -845,7 +899,7 @@ defmodule BroadwayTest do
     end
 
     test "batches are created normally (without the lost messages)", %{broadway: broadway} do
-      Broadway.test_messages(broadway, [1, 2, :kill_processor, 3, 4, 5])
+      Broadway.test_messages(broadway, [1, 2, :kill_processor, 3, 4, 5], batching_mode: :bulk)
 
       assert_receive {:batch_handled, messages}
       values = messages |> Enum.map(& &1.data)
@@ -904,15 +958,15 @@ defmodule BroadwayTest do
     end
 
     test "batcher will be restarted in order to handle other messages", %{broadway: broadway} do
-      Broadway.test_messages(broadway, [1, 2])
+      Broadway.test_messages(broadway, [1, 2], batching_mode: :bulk)
       assert_receive {:batch_handled, _, batcher1} when is_pid(batcher1)
       ref = Process.monitor(batcher1)
 
-      Broadway.test_messages(broadway, [:kill_batcher, 3])
+      Broadway.test_messages(broadway, [:kill_batcher, 3], batching_mode: :bulk)
       assert_receive {:batch_handled, _, ^batcher1}
       assert_receive {:DOWN, ^ref, _, _, _}
 
-      Broadway.test_messages(broadway, [4, 5])
+      Broadway.test_messages(broadway, [4, 5], batching_mode: :bulk)
       assert_receive {:batch_handled, _, batcher2} when is_pid(batcher2)
       assert batcher1 != batcher2
     end
@@ -939,7 +993,10 @@ defmodule BroadwayTest do
     end
 
     test "only the messages in the crashing batcher are lost", %{broadway: broadway} do
-      ref = Broadway.test_messages(broadway, [1, 2, :kill_batcher, 3, 4, 5, 6, 7])
+      ref =
+        Broadway.test_messages(broadway, [1, 2, :kill_batcher, 3, 4, 5, 6, 7],
+          batching_mode: :bulk
+        )
 
       assert_receive {:ack, ^ref, successful, _failed}
       values = Enum.map(successful, & &1.data)
@@ -1014,7 +1071,7 @@ defmodule BroadwayTest do
     test "all messages in the batch are marked as {:failed, reason} when an error is raised",
          %{broadway: broadway, consumer: consumer} do
       assert capture_log(fn ->
-               ref = Broadway.test_messages(broadway, [1, 2, :raise, 3])
+               ref = Broadway.test_messages(broadway, [1, 2, :raise, 3], batching_mode: :bulk)
 
                assert_receive {:ack, ^ref, [],
                                [
@@ -1031,7 +1088,8 @@ defmodule BroadwayTest do
     test "all messages in the batch are marked as {:failed, reason} on bad return",
          %{broadway: broadway, consumer: consumer} do
       assert capture_log(fn ->
-               ref = Broadway.test_messages(broadway, [1, 2, :bad_return, 3])
+               ref =
+                 Broadway.test_messages(broadway, [1, 2, :bad_return, 3], batching_mode: :bulk)
 
                assert_receive {:ack, ^ref, [],
                                [
@@ -1055,7 +1113,7 @@ defmodule BroadwayTest do
 
       assert capture_log(fn ->
                Broadway.push_messages(broadway, [one, two, raise, three])
-               ref = Broadway.test_messages(broadway, [1, 2, 3, 4])
+               ref = Broadway.test_messages(broadway, [1, 2, 3, 4], batching_mode: :bulk)
                assert_receive {:ack, ^ref, [%{data: 1}, %{data: 2}, %{data: 3}, %{data: 4}], []}
              end) =~ "[error] ** (UndefinedFunctionError) function Unknown.ack/3 is undefined"
 
@@ -1065,7 +1123,8 @@ defmodule BroadwayTest do
     test "consumers do not crash on broken link",
          %{broadway: broadway, consumer: consumer} do
       assert capture_log(fn ->
-               ref = Broadway.test_messages(broadway, [1, 2, :broken_link, 3])
+               ref =
+                 Broadway.test_messages(broadway, [1, 2, :broken_link, 3], batching_mode: :bulk)
 
                assert_receive {:ack, ^ref, [],
                                [
@@ -1142,7 +1201,7 @@ defmodule BroadwayTest do
 
     test "shutting down broadway waits until all events are processed even on incomplete batches",
          %{broadway: broadway} do
-      ref = Broadway.test_messages(broadway, [1, 2])
+      ref = Broadway.test_messages(broadway, [1, 2], batching_mode: :bulk)
       Process.exit(broadway, :shutdown)
       assert_receive {:ack, ^ref, [%{data: 1}, %{data: 2}], []}
     end


### PR DESCRIPTION
Closes #92.

Worth mentioning that for people using default batch size of 100 the following works:

```elixir
ref = Broadway.test_messages(broadway, [1, 2, 3, 4])
assert_receive {:ack, ^ref, [%{data: 1}, %{data: 2}, %{data: 3}, %{data: 4}], []}
```

so it's not that people would necessarily get a lot more acknowledgments, we only got them (which required us to tweak our tests) because we had low batch size in tests.