### PR TITLE
Add Broadway.Message.configure_ack/3

### DIFF
--- a/lib/broadway/acknowledger.ex
+++ b/lib/broadway/acknowledger.ex
@@ -39,6 +39,14 @@ defmodule Broadway.Acknowledger do
               :ok
 
   @doc """
+  TODO
+  """
+  @callback configure(ack_ref :: {pid, reference}, ack_data :: term, options :: keyword) ::
+              {ack_ref :: {pid, reference}, ack_data :: term}
+
+  @optional_callbacks [configure: 3]
+
+  @doc """
   Acknowledges successful and failed messages grouped by `{acknowledger, ack_ref}`.
   """
   @spec ack_messages([Message.t()], [Message.t()]) :: no_return

--- a/lib/broadway/acknowledger.ex
+++ b/lib/broadway/acknowledger.ex
@@ -35,7 +35,7 @@ defmodule Broadway.Acknowledger do
       could not be processed or published.
 
   """
-  @callback ack(ack_ref :: {pid, reference}, successful :: [Message.t()], failed :: [Message.t()]) ::
+  @callback ack(ack_ref :: term, successful :: [Message.t()], failed :: [Message.t()]) ::
               :ok
 
   @doc """
@@ -45,8 +45,12 @@ defmodule Broadway.Acknowledger do
   `ack_data`. The `ack_data` is the current acknowledger's data. The return value
   of this function is `{:ok, new_ack_data}` where `new_ack_data` is the updated
   data for the acknowledger.
+
+  Note that `options` are different for every acknowledger, as the acknowledger
+  is what specifies what are the supported options. Check the documentation for the
+  acknowledger you're using to see the supported options.
   """
-  @callback configure(ack_ref :: {pid, reference}, ack_data :: term, options :: keyword) ::
+  @callback configure(ack_ref :: term, ack_data :: term, options :: keyword) ::
               {:ok, new_ack_data :: term}
 
   @optional_callbacks [configure: 3]

--- a/lib/broadway/acknowledger.ex
+++ b/lib/broadway/acknowledger.ex
@@ -39,10 +39,15 @@ defmodule Broadway.Acknowledger do
               :ok
 
   @doc """
-  TODO
+  Configures the acknowledger with new `options`.
+
+  Every acknowledger can decide how to incorporate the given `options` into its
+  `ack_data`. The `ack_data` is the current acknowledger's data. The return value
+  of this function is `{:ok, new_ack_data}` where `new_ack_data` is the updated
+  data for the acknowledger.
   """
   @callback configure(ack_ref :: {pid, reference}, ack_data :: term, options :: keyword) ::
-              {ack_ref :: {pid, reference}, ack_data :: term}
+              {:ok, new_ack_data :: term}
 
   @optional_callbacks [configure: 3]
 

--- a/lib/broadway/caller_acknowledger.ex
+++ b/lib/broadway/caller_acknowledger.ex
@@ -13,6 +13,12 @@ defmodule Broadway.CallerAcknowledger do
   It sends a message in the format:
 
       {:ack, ref, successful_messages, failed_messages}
+
+  If `Broadway.Message.configure_ack/3` is called on a message that
+  uses this acknowledger, then the following message is sent:
+
+      {:configure, ref}
+
   """
 
   @behaviour Broadway.Acknowledger
@@ -20,5 +26,10 @@ defmodule Broadway.CallerAcknowledger do
   @impl true
   def ack({pid, ref}, successful, failed) do
     send(pid, {:ack, ref, successful, failed})
+  end
+
+  @impl true
+  def configure({pid, ref}, _ack_data, _options) do
+    send(pid, {:configure, ref})
   end
 end

--- a/lib/broadway/caller_acknowledger.ex
+++ b/lib/broadway/caller_acknowledger.ex
@@ -17,7 +17,7 @@ defmodule Broadway.CallerAcknowledger do
   If `Broadway.Message.configure_ack/3` is called on a message that
   uses this acknowledger, then the following message is sent:
 
-      {:configure, ref}
+      {:configure, ref, options}
 
   """
 
@@ -29,7 +29,8 @@ defmodule Broadway.CallerAcknowledger do
   end
 
   @impl true
-  def configure({pid, ref}, _ack_data, _options) do
-    send(pid, {:configure, ref})
+  def configure({pid, ref}, ack_data, options) do
+    send(pid, {:configure, ref, options})
+    {:ok, ack_data}
   end
 end

--- a/lib/broadway/message.ex
+++ b/lib/broadway/message.ex
@@ -94,12 +94,12 @@ defmodule Broadway.Message do
   def configure_ack(%Message{} = message, options) when is_list(options) do
     %{acknowledger: {module, ack_ref, ack_data}} = message
 
-    # if function_exported?(module, :configure, 3) do
-    {:ok, ack_data} = module.configure(ack_ref, ack_data, options)
-    %{message | acknowledger: {module, ack_ref, ack_data}}
-    # else
-    # raise "the configure/3 callback is not defined by acknowledger #{inspect(module)}"
-    # end
+    if function_exported?(module, :configure, 3) do
+      {:ok, ack_data} = module.configure(ack_ref, ack_data, options)
+      %{message | acknowledger: {module, ack_ref, ack_data}}
+    else
+      raise "the configure/3 callback is not defined by acknowledger #{inspect(module)}"
+    end
   end
 
   @doc """

--- a/lib/broadway/message.ex
+++ b/lib/broadway/message.ex
@@ -82,14 +82,20 @@ defmodule Broadway.Message do
   end
 
   @doc """
-  TODO
+  Configures the acknowledger of this message.
+
+  This function calls the `c:Broadway.Acknowledger.configure/3` callback to
+  change the configuration of the acknowledger for the given `message`.
+
+  This function can only be called if the acknowledger implements the `configure/3`
+  callback. If it doesn't, an error is raised.
   """
   @spec configure_ack(message :: Message.t(), options :: keyword) :: Message.t()
   def configure_ack(%Message{} = message, options) when is_list(options) do
     %{acknowledger: {module, ack_ref, ack_data}} = message
 
     if function_exported?(module, :configure, 3) do
-      {ack_ref, ack_data} = module.configure(ack_ref, ack_data, options)
+      {:ok, ack_data} = module.configure(ack_ref, ack_data, options)
       %{message | acknowledger: {module, ack_ref, ack_data}}
     else
       raise "the configure/3 callback is not exported by acknowledger #{inspect(module)}"

--- a/lib/broadway/message.ex
+++ b/lib/broadway/message.ex
@@ -82,6 +82,21 @@ defmodule Broadway.Message do
   end
 
   @doc """
+  TODO
+  """
+  @spec configure_ack(message :: Message.t(), options :: keyword) :: Message.t()
+  def configure_ack(%Message{} = message, options) when is_list(options) do
+    %{acknowledger: {module, ack_ref, ack_data}} = message
+
+    if function_exported?(module, :configure, 3) do
+      {ack_ref, ack_data} = module.configure(ack_ref, ack_data, options)
+      %{message | acknowledger: {module, ack_ref, ack_data}}
+    else
+      raise "the configure/3 callback is not exported by acknowledger #{inspect(module)}"
+    end
+  end
+
+  @doc """
   Mark a message as failed.
 
   Failed messages are sent directly to the related acknowledger so they're not

--- a/lib/broadway/message.ex
+++ b/lib/broadway/message.ex
@@ -94,12 +94,12 @@ defmodule Broadway.Message do
   def configure_ack(%Message{} = message, options) when is_list(options) do
     %{acknowledger: {module, ack_ref, ack_data}} = message
 
-    if function_exported?(module, :configure, 3) do
-      {:ok, ack_data} = module.configure(ack_ref, ack_data, options)
-      %{message | acknowledger: {module, ack_ref, ack_data}}
-    else
-      raise "the configure/3 callback is not exported by acknowledger #{inspect(module)}"
-    end
+    # if function_exported?(module, :configure, 3) do
+    {:ok, ack_data} = module.configure(ack_ref, ack_data, options)
+    %{message | acknowledger: {module, ack_ref, ack_data}}
+    # else
+    # raise "the configure/3 callback is not defined by acknowledger #{inspect(module)}"
+    # end
   end
 
   @doc """

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -23,16 +23,6 @@ defmodule BroadwayTest do
     end
   end
 
-  defmodule AckerWithConfigure do
-    @behaviour Broadway.Acknowledger
-
-    defdelegate ack(ack_ref, successful, failed), to: BroadwayTest.Acker
-
-    def configure(_ack_ref, ack_data, options) do
-      {:ok, Map.replace!(ack_data, :test_pid, Keyword.fetch!(options, :test_pid))}
-    end
-  end
-
   defmodule ManualProducer do
     use GenStage
 

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -767,12 +767,17 @@ defmodule BroadwayTest do
           processors: [default: []]
         )
 
-      Broadway.push_messages(broadway, [
-        %Message{data: 1, acknowledger: {Acker, nil, %{test_pid: self()}}}
-      ])
+      log =
+        capture_log(fn ->
+          Broadway.push_messages(broadway, [
+            %Message{data: 1, acknowledger: {Acker, nil, %{test_pid: self()}}}
+          ])
 
-      assert_receive {:ack, _successful = [], [failed]}
-      assert failed.status == {:failed, "due to an unhandled error"}
+          assert_receive {:ack, _successful = [], [failed]}
+          assert failed.status == {:failed, "due to an unhandled error"}
+        end)
+
+      assert log =~ "the configure/3 callback is not defined by acknowledger BroadwayTest.Acker"
     end
 
     test "configures the acknowledger" do


### PR DESCRIPTION
Some notes:

  * I didn't add the `configure/3` callback to `NoopAcknowledger` because I think it's good if it raises if you call `configure_ack/3` after calling `ack_immediately`. Do we want to implement it and raise an even better message?

  * Do we need to support a list of messages in `configure_ack/3`?