### PR TITLE
Ensure transformer is applied in `Broadway.test_messages`

### DIFF
--- a/lib/broadway/producer.ex
+++ b/lib/broadway/producer.ex
@@ -36,6 +36,11 @@ defmodule Broadway.Producer do
     GenStage.call(producer, {__MODULE__, :push_messages, messages})
   end
 
+  @spec transformer(GenServer.server()) :: nil | {atom, atom, Keyword.t()}
+  def transformer(producer) do
+    GenStage.call(producer, :transformer)
+  end
+
   @spec drain(GenServer.server()) :: :ok
   def drain(producer) do
     GenStage.cast(producer, {__MODULE__, :prepare_for_draining})
@@ -143,6 +148,11 @@ defmodule Broadway.Producer do
   @impl true
   def handle_call({__MODULE__, :push_messages, messages}, _from, state) do
     {:reply, :ok, messages, state}
+  end
+
+  def handle_call(:transformer, _from, state) do
+    %{transformer: transformer} = state
+    {:reply, transformer, [], state}
   end
 
   @impl true

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -857,7 +857,7 @@ defmodule BroadwayTest do
         )
 
       producer = get_producer(broadway_name)
-      %{producer: producer}
+      %{producer: producer, broadway: broadway_name}
     end
 
     test "transform all events", %{producer: producer} do
@@ -876,6 +876,18 @@ defmodule BroadwayTest do
       assert_receive {:message_handled, "2 transformed"}
       assert_receive {:DOWN, ^ref_producer, _, _, _}
       refute_received {:message_handled, "3 transformed"}
+    end
+
+    test "applies transform on Broadway.test_messages/2", %{broadway: name} do
+      Broadway.test_messages(name, [1, 2])
+
+      assert_receive {:message_handled, 1}
+      assert_receive {:message_handled, 2}
+
+      Broadway.test_messages(name, [1, 2], transform: true)
+
+      assert_receive {:message_handled, %{data: "1 transformed"}}
+      assert_receive {:message_handled, %{data: "2 transformed"}}
     end
   end
 


### PR DESCRIPTION
To completely simulate a payload -> effects execution in tests, the configured transformer should be called on `Broadway.test_messages/2`.

This enables to optionally call the transformer (so current test suites do not break).