### PR TITLE
Proper atom type in Message's Typespec

### DIFF
--- a/lib/broadway/message.ex
+++ b/lib/broadway/message.ex
@@ -17,7 +17,7 @@ defmodule Broadway.Message do
 
   @type t :: %Message{
           data: term,
-          metadata: %{optional(:atom) => term},
+          metadata: %{optional(atom) => term},
           acknowledger: {module, ack_ref :: term, data :: term},
           batcher: atom,
           batch_key: term,


### PR DESCRIPTION
With `:atom`, Dialyzer expects an atom named `:atom` as a key!