### PR TITLE
Add doc groups for modules

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -47,6 +47,25 @@ defmodule Broadway.MixProject do
       groups_for_extras: [
         Examples: Path.wildcard("guides/examples/*.md"),
         Internals: Path.wildcard("guides/internals/*.md")
+      ],
+      groups_for_modules: [
+        # Ungrouped Modules:
+        #
+        # Broadway
+        # Broadway.Message
+
+        Acknowledgement: [
+          Broadway.Acknowledger,
+          Broadway.CallerAcknowledger,
+          Broadway.NoopAcknowledger
+        ],
+        Batching: [
+          Broadway.BatchInfo
+        ],
+        Producers: [
+          Broadway.DummyProducer,
+          Broadway.TermStorage
+        ]
       ]
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -53,14 +53,12 @@ defmodule Broadway.MixProject do
         #
         # Broadway
         # Broadway.Message
+        # Broadway.BatchInfo
 
         Acknowledgement: [
           Broadway.Acknowledger,
           Broadway.CallerAcknowledger,
           Broadway.NoopAcknowledger
-        ],
-        Batching: [
-          Broadway.BatchInfo
         ],
         Producers: [
           Broadway.DummyProducer,


### PR DESCRIPTION
Broadway has a few more public modules now, so I thought it might be helpful to add some grouping in the docs.

