### PR TITLE
Add support for rate limiting producers

### DIFF
--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -603,8 +603,9 @@ defmodule Broadway do
     * `:rate_limiting` - Optional. A list of options to enable and configure
       rate limiting for producing. If this option is present, rate limiting is
       enabled, otherwise it isn't. Rate limiting refers to the rate at which
-      producers will forward messages to the rest of the pipeline. The
-      following options are supported:
+      producers will forward messages to the rest of the pipeline. The rate
+      limiting is applied to and shared by all producers within the time limit.
+      The following options are supported:
 
         * `:allowed_messages` - Required. An integer that describes how many
           messages are allowed in the specified interval.

--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -600,6 +600,22 @@ defmodule Broadway do
        `:transformer` callback will cause the whole producer to terminate,
        possibly leaving unacknowledged messages along the way.
 
+    * `:rate_limiting` - Optional. A list of options to enable and configure
+      rate limiting for producing. If this option is present, rate limiting is
+      enabled, otherwise it isn't. Rate limiting refers to the rate at which
+      the publisher will forward messages to the rest of the pipeline. The
+      following options are supported:
+
+        * `:allowed_messages` - Required. An integer that describes how many
+          messages are allowed in the specified interval.
+
+        * `:interval` - Required. An integer that describes the interval
+         (in milliseconds) during which the number of allowed messages is
+         allowed. If the producer produces more than `allowed_messages`
+         in `interval`, only `allowed_messages` will be published until
+         the end of `interval`, and then more messages will be published.
+
+        * `:buffer_size` - Optional. The size of the internal buffer where
     * `:hibernate_after` - Optional. Overrides the top-level `:hibernate_after`.
 
     * `:spawn_opt` - Optional. Overrides the top-level `:spawn_opt`.
@@ -789,7 +805,14 @@ defmodule Broadway do
           stages: [type: :pos_integer, default: 1],
           transformer: [type: :mfa, default: nil],
           spawn_opt: [type: :keyword_list],
-          hibernate_after: [type: :pos_integer]
+          hibernate_after: [type: :pos_integer],
+          rate_limiting: [
+            type: :non_empty_keyword_list,
+            keys: [
+              allowed_messages: [required: true, type: :pos_integer],
+              interval: [required: true, type: :pos_integer]
+            ]
+          ]
         ]
       ],
       processors: [

--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -603,7 +603,7 @@ defmodule Broadway do
     * `:rate_limiting` - Optional. A list of options to enable and configure
       rate limiting for producing. If this option is present, rate limiting is
       enabled, otherwise it isn't. Rate limiting refers to the rate at which
-      the publisher will forward messages to the rest of the pipeline. The
+      producers will forward messages to the rest of the pipeline. The
       following options are supported:
 
         * `:allowed_messages` - Required. An integer that describes how many

--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -615,7 +615,6 @@ defmodule Broadway do
          in `interval`, only `allowed_messages` will be published until
          the end of `interval`, and then more messages will be published.
 
-        * `:buffer_size` - Optional. The size of the internal buffer where
     * `:hibernate_after` - Optional. Overrides the top-level `:hibernate_after`.
 
     * `:spawn_opt` - Optional. Overrides the top-level `:spawn_opt`.

--- a/lib/broadway/producer.ex
+++ b/lib/broadway/producer.ex
@@ -188,13 +188,11 @@ defmodule Broadway.Producer do
 
   @impl true
   def handle_info({__MODULE__, :cancel_consumers}, %{rate_limiting: %{} = rate_limiting} = state) do
-    rate_limiting =
-      if :queue.is_empty(rate_limiting.message_buffer) do
-        cancel_consumers(state)
-        rate_limiting
-      else
-        %{rate_limiting | draining?: true}
-      end
+    rate_limiting = %{rate_limiting | draining?: true}
+
+    if :queue.is_empty(rate_limiting.message_buffer) do
+      cancel_consumers(state)
+    end
 
     {:noreply, [], %{state | rate_limiting: rate_limiting}}
   end

--- a/lib/broadway/producer.ex
+++ b/lib/broadway/producer.ex
@@ -123,11 +123,9 @@ defmodule Broadway.Producer do
     {:noreply, [], update_in(state.consumers, &List.delete(&1, from))}
   end
 
-  @impl true
-  def handle_demand(demand, state)
-
   # If we're rate limited, we store the demand in the buffer instead of forwarding it.
   # We'll forward it once the rate limit is lifted.
+  @impl true
   def handle_demand(demand, %{rate_limiting: %{state: :closed}} = state) do
     state = update_in(state.rate_limiting.demand_buffer, &:queue.in(demand, &1))
     {:noreply, [], state}

--- a/lib/broadway/producer.ex
+++ b/lib/broadway/producer.ex
@@ -233,7 +233,9 @@ defmodule Broadway.Producer do
     {state, messages} = rate_limit_and_buffer_messages(state)
 
     # If we're not rate limited after emptying the buffer, we'll forward demand upstream.
-    schedule_next_handle_demand_if_rate_limiting_open(state)
+    unless state.rate_limiting.draining? do
+      schedule_next_handle_demand_if_rate_limiting_open(state)
+    end
 
     {:noreply, messages, state}
   end

--- a/lib/broadway/producer.ex
+++ b/lib/broadway/producer.ex
@@ -291,7 +291,7 @@ defmodule Broadway.Producer do
     state = put_in(state.rate_limiting.message_buffer, new_buffer)
 
     state =
-      if allowed_left == 0 or unsent == [] do
+      if unsent == [] do
         state
       else
         put_in(state.rate_limiting.state, :closed)

--- a/lib/broadway/producer.ex
+++ b/lib/broadway/producer.ex
@@ -225,6 +225,12 @@ defmodule Broadway.Producer do
     end
   end
 
+  # If the rate limit is lifted but our rate limiting state was "open",
+  # we don't need to do anything since we don't have anything in the buffer.
+  def handle_info({RateLimiter, :reset_rate_limiting}, %{rate_limiting: %{state: :open}} = state) do
+    {:noreply, [], state}
+  end
+
   def handle_info({RateLimiter, :reset_rate_limiting}, state) do
     state = put_in(state.rate_limiting.state, :open)
 

--- a/lib/broadway/rate_limiter.ex
+++ b/lib/broadway/rate_limiter.ex
@@ -13,8 +13,7 @@ defmodule Broadway.RateLimiter do
 
       rate_limiting_opts ->
         name = Keyword.fetch!(opts, :name)
-        genserver_opts = [name: Module.concat(name, __MODULE__)]
-        GenServer.start_link(__MODULE__, {name, rate_limiting_opts}, genserver_opts)
+        GenServer.start_link(__MODULE__, {name, rate_limiting_opts}, name: table_name(name))
     end
   end
 
@@ -28,7 +27,7 @@ defmodule Broadway.RateLimiter do
   end
 
   def table_name(broadway_name) when is_atom(broadway_name) do
-    Module.concat(broadway_name, RateLimiterETS)
+    Module.concat(broadway_name, RateLimiter)
   end
 
   @impl true

--- a/lib/broadway/rate_limiter.ex
+++ b/lib/broadway/rate_limiter.ex
@@ -13,7 +13,8 @@ defmodule Broadway.RateLimiter do
 
       rate_limiting_opts ->
         name = Keyword.fetch!(opts, :name)
-        GenServer.start_link(__MODULE__, {name, rate_limiting_opts})
+        genserver_opts = [name: Module.concat(name, __MODULE__)]
+        GenServer.start_link(__MODULE__, {name, rate_limiting_opts}, genserver_opts)
     end
   end
 

--- a/lib/broadway/rate_limiter.ex
+++ b/lib/broadway/rate_limiter.ex
@@ -59,11 +59,10 @@ defmodule Broadway.RateLimiter do
 
     true = :ets.insert(table, {@row_name, allowed})
 
-    Enum.each(producers_names, fn name ->
-      if pid = Process.whereis(name) do
-        send(pid, {__MODULE__, :reset_rate_limiting})
-      end
-    end)
+    for name <- producers_names,
+        pid = Process.whereis(name),
+        is_pid(pid),
+        do: send(pid, {__MODULE__, :reset_rate_limiting})
 
     _ = schedule_next_reset(interval)
 

--- a/lib/broadway/rate_limiter.ex
+++ b/lib/broadway/rate_limiter.ex
@@ -19,10 +19,7 @@ defmodule Broadway.RateLimiter do
 
   def rate_limit(table_name, amount)
       when is_atom(table_name) and is_integer(amount) and amount > 0 do
-    case :ets.update_counter(table_name, @row_name, -amount) do
-      left when left >= 0 -> {:ok, left}
-      overflow -> {:rate_limited, overflow}
-    end
+    :ets.update_counter(table_name, @row_name, -amount)
   end
 
   def get_currently_allowed(table_name) when is_atom(table_name) do

--- a/lib/broadway/rate_limiter.ex
+++ b/lib/broadway/rate_limiter.ex
@@ -33,6 +33,10 @@ defmodule Broadway.RateLimiter do
     end
   end
 
+  def get_currently_allowed(broadway_name) do
+    :ets.lookup_element(table_name(broadway_name), @row_name, 2)
+  end
+
   @impl true
   def init({name, rate_limiting_opts}) do
     interval = Keyword.fetch!(rate_limiting_opts, :interval)

--- a/lib/broadway/rate_limiter.ex
+++ b/lib/broadway/rate_limiter.ex
@@ -20,7 +20,7 @@ defmodule Broadway.RateLimiter do
   def rate_limit(table_name, amount)
       when is_atom(table_name) and is_integer(amount) and amount > 0 do
     case :ets.update_counter(table_name, @row_name, -amount) do
-      left when left >= 0 -> :ok
+      left when left >= 0 -> {:ok, left}
       overflow -> {:rate_limited, overflow}
     end
   end

--- a/lib/broadway/rate_limiter.ex
+++ b/lib/broadway/rate_limiter.ex
@@ -44,17 +44,11 @@ defmodule Broadway.RateLimiter do
 
   @impl true
   def handle_info({:reset_limit, allowed}, {broadway_name, interval}) do
-    # Taken from this match spec:
-    # :ets.fun2ms(fn {@row_name, counter} when counter < allowed -> {@row_name, allowed} end)
-    match_spec = [
-      {{@row_name, :"$1"}, [{:<, :"$1", {:const, allowed}}], [{{@row_name, {:const, allowed}}}]}
-    ]
+    was_rate_limited? = get_currently_allowed(broadway_name) <= 0
 
-    # This returns the number of updated rows. If it's 1, it means that we updated the counter
-    # which in turn means that we didn't have any events allowed anymore so producers might
-    # have buffered messages. In that case, we notify the producers that new rate limiting
-    # is available.
-    if :ets.select_replace(table_name(broadway_name), match_spec) == 1 do
+    true = :ets.insert(table_name(broadway_name), {@row_name, allowed})
+
+    if was_rate_limited? do
       producers = Broadway.producer_names(broadway_name)
       Enum.each(producers, &send(&1, {__MODULE__, :reset_rate_limiting}))
     end

--- a/lib/broadway/rate_limiter.ex
+++ b/lib/broadway/rate_limiter.ex
@@ -58,13 +58,9 @@ defmodule Broadway.RateLimiter do
   def handle_info(:reset_limit, state) do
     %{producers: producers, interval: interval, allowed: allowed, table: table} = state
 
-    was_rate_limited? = get_currently_allowed(table) <= 0
-
     true = :ets.insert(table, {@row_name, allowed})
 
-    if was_rate_limited? do
-      Enum.each(producers, &send(&1, {__MODULE__, :reset_rate_limiting}))
-    end
+    :ok = Enum.each(producers, &send(&1, {__MODULE__, :reset_rate_limiting}))
 
     _ = schedule_next_reset(interval)
 

--- a/lib/broadway/rate_limiter.ex
+++ b/lib/broadway/rate_limiter.ex
@@ -1,4 +1,5 @@
 defmodule Broadway.RateLimiter do
+  # TODO: Use :counters once we require Erlang/OTP 22+
   @moduledoc false
 
   use GenServer

--- a/lib/broadway/rate_limiter.ex
+++ b/lib/broadway/rate_limiter.ex
@@ -1,0 +1,73 @@
+defmodule Broadway.RateLimiter do
+  @moduledoc false
+
+  use GenServer
+  @row_name :rate_limit_counter
+
+  def start_link(opts) do
+    case Keyword.fetch!(opts, :rate_limiting) do
+      # If we don't have rate limiting options, we don't even need to start this rate
+      # limiter process.
+      nil ->
+        :ignore
+
+      rate_limiting_opts ->
+        name = Keyword.fetch!(opts, :name)
+        GenServer.start_link(__MODULE__, {name, rate_limiting_opts})
+    end
+  end
+
+  def decrease_counter_or_rate_limit(broadway_name) do
+    # We're decrementing by 1. We're setting a threshold of 0, which means that
+    # if the counter would go below 0, it's reset to set_value (-1) instead.
+    # This ensures that the first time we go below 0, we reset to -1 and return -1.
+    # Then every other time we're going to decrement from -1 to -2, reset to -1
+    # because it's below the threshold, and return -1 again. So -1 means that we
+    # are below the rate limiting.
+
+    update_op = {_position = 2, _incr = -1, _threshold = 0, _set_value = -1}
+
+    case :ets.update_counter(table_name(broadway_name), @row_name, update_op) do
+      -1 -> :rate_limited
+      _other -> :ok
+    end
+  end
+
+  @impl true
+  def init({name, rate_limiting_opts}) do
+    interval = Keyword.fetch!(rate_limiting_opts, :interval)
+    allowed = Keyword.fetch!(rate_limiting_opts, :allowed_messages)
+
+    table_name = table_name(name)
+    _ets = :ets.new(table_name, [:named_table, :public, :set])
+    :ets.insert(table_name, {@row_name, allowed})
+
+    :timer.send_interval(interval, {:reset_limit, allowed})
+
+    {:ok, name}
+  end
+
+  @impl true
+  def handle_info({:reset_limit, allowed}, broadway_name) do
+    # Taken from this match spec:
+    # :ets.fun2ms(fn {@row_name, counter} when counter < allowed -> {@row_name, allowed} end)
+    match_spec = [
+      {{@row_name, :"$1"}, [{:<, :"$1", {:const, allowed}}], [{{@row_name, {:const, allowed}}}]}
+    ]
+
+    # This returns the number of updated rows. If it's 1, it means that we updated the counter
+    # which in turn means that we didn't have any events allowed anymore so producers might
+    # have buffered messages. In that case, we notify the producers that new rate limiting
+    # is available.
+    if :ets.select_replace(table_name(broadway_name), match_spec) == 1 do
+      producers = Broadway.producer_names(broadway_name)
+      Enum.each(producers, &send(&1, {__MODULE__, :reset_rate_limiting}))
+    end
+
+    {:noreply, broadway_name}
+  end
+
+  defp table_name(broadway_name) do
+    Module.concat(broadway_name, RateLimiterETS)
+  end
+end

--- a/lib/broadway/server.ex
+++ b/lib/broadway/server.ex
@@ -78,7 +78,7 @@ defmodule Broadway.Server do
 
     children =
       [
-        build_rate_limiter_spec(config),
+        build_rate_limiter_spec(config, producers_names),
         build_producer_supervisor_spec(config, producers_specs),
         build_processor_supervisor_spec(config, processors_specs)
       ] ++
@@ -114,9 +114,16 @@ defmodule Broadway.Server do
     [name: name] ++ Keyword.take(config, [:spawn_opt, :hibernate_after])
   end
 
-  defp build_rate_limiter_spec(config) do
+  defp build_rate_limiter_spec(config, producers_names) do
     %{name: broadway_name, producer_config: producer_config} = config
-    {RateLimiter, name: broadway_name, rate_limiting: producer_config[:rate_limiting]}
+
+    opts = [
+      name: broadway_name,
+      rate_limiting: producer_config[:rate_limiting],
+      producers_names: producers_names
+    ]
+
+    {RateLimiter, opts}
   end
 
   defp build_producers_specs(config, opts) do

--- a/test/broadway/producer_test.exs
+++ b/test/broadway/producer_test.exs
@@ -66,7 +66,14 @@ defmodule Broadway.ProducerTest do
   end
 
   setup do
-    %{state: %{module: FakeProducer, transformer: nil, module_state: nil}}
+    %{
+      state: %{
+        module: FakeProducer,
+        transformer: nil,
+        module_state: nil,
+        rate_limiting: nil
+      }
+    }
   end
 
   test "init with bad return" do

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -1855,8 +1855,8 @@ defmodule BroadwayTest do
 
       # Now, since the rate limiting interval is long, we can assert that
       # handle_demand is not called and that the third message is not emitted yet.
-      refute_receive {:handle_demand_called, _demand}
-      refute_receive {:handle_message_called, %Message{data: 3}}, 500
+      refute_received {:handle_demand_called, _demand}
+      refute_received {:handle_message_called, %Message{data: 3}}, 500
 
       # We "cheat" and manually tell the rate limiter to reset the limit.
       send(get_rate_limiter(broadway_name), :reset_limit)

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -1777,6 +1777,7 @@ defmodule BroadwayTest do
           name: broadway_name,
           producer: [
             module: {ManualProducer, []},
+            stages: 2,
             rate_limiting: [allowed_messages: 2, interval: 50]
           ],
           processors: [default: []],

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -1761,6 +1761,8 @@ defmodule BroadwayTest do
   end
 
   describe "rate limiting" do
+    @describetag :focus
+
     test "with an interval and a number of allowed messages in that interval" do
       broadway_name = new_unique_name()
       test_pid = self()

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -1936,7 +1936,7 @@ defmodule BroadwayTest do
   end
 
   defp get_rate_limiter(broadway_name) do
-    :"#{broadway_name}.Broadway.RateLimiter"
+    :"#{broadway_name}.RateLimiter"
   end
 
   defp get_n_producers(broadway_name) do

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -29,7 +29,7 @@ defmodule BroadwayTest do
     @impl true
     def handle_demand(demand, state) do
       if test_pid = state[:test_pid] do
-        send(test_pid, {:handle_demand_called, demand, System.system_time()})
+        send(test_pid, {:handle_demand_called, demand, System.monotonic_time()})
       end
 
       {:noreply, [], state}
@@ -1770,7 +1770,7 @@ defmodule BroadwayTest do
       test_pid = self()
 
       handle_message = fn message, _ ->
-        send(test_pid, {:handle_message_called, message, System.system_time()})
+        send(test_pid, {:handle_message_called, message, System.monotonic_time()})
         message
       end
 
@@ -1820,7 +1820,7 @@ defmodule BroadwayTest do
       test_pid = self()
 
       handle_message = fn message, _ ->
-        send(test_pid, {:handle_message_called, message, System.system_time()})
+        send(test_pid, {:handle_message_called, message, System.monotonic_time()})
         message
       end
 
@@ -1877,7 +1877,7 @@ defmodule BroadwayTest do
       test_pid = self()
 
       handle_message = fn message, _ ->
-        send(test_pid, {:handle_message_called, message, System.system_time()})
+        send(test_pid, {:handle_message_called, message, System.monotonic_time()})
         message
       end
 

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -1856,7 +1856,7 @@ defmodule BroadwayTest do
       # Now, since the rate limiting interval is long, we can assert that
       # handle_demand is not called and that the third message is not emitted yet.
       refute_received {:handle_demand_called, _demand}
-      refute_received {:handle_message_called, %Message{data: 3}}, 500
+      refute_received {:handle_message_called, %Message{data: 3}}
 
       # We "cheat" and manually tell the rate limiter to reset the limit.
       send(get_rate_limiter(broadway_name), :reset_limit)

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -1896,7 +1896,8 @@ defmodule BroadwayTest do
         {:push_messages,
          [
            %Message{data: 1, acknowledger: {CallerAcknowledger, {self(), :ref}, :unused}},
-           %Message{data: 2, acknowledger: {CallerAcknowledger, {self(), :ref}, :unused}}
+           %Message{data: 2, acknowledger: {CallerAcknowledger, {self(), :ref}, :unused}},
+           %Message{data: 3, acknowledger: {CallerAcknowledger, {self(), :ref}, :unused}}
          ]}
       )
 
@@ -1907,10 +1908,11 @@ defmodule BroadwayTest do
       # the ManualProducer.
       Process.exit(broadway, :shutdown)
 
-      refute_receive {:handle_message_called, %Broadway.Message{data: :message_during_cancel}}
+      refute_received {:handle_message_called, %Broadway.Message{data: :message_during_cancel}}
 
       send(get_rate_limiter(broadway_name), :reset_limit)
 
+      assert_receive {:handle_message_called, %Broadway.Message{data: 3}}
       assert_receive {:handle_message_called, %Broadway.Message{data: :message_during_cancel}}
     end
   end

--- a/test/broadway_test.exs
+++ b/test/broadway_test.exs
@@ -1859,7 +1859,7 @@ defmodule BroadwayTest do
       refute_receive {:handle_message_called, %Message{data: 3}}, 500
 
       # We "cheat" and manually tell the rate limiter to reset the limit.
-      send(get_rate_limiter(broadway_name), {:reset_limit, _allowed = 2})
+      send(get_rate_limiter(broadway_name), :reset_limit)
 
       assert_receive {:handle_demand_called, _demand}
       assert_receive {:handle_message_called, %Message{data: 3}}
@@ -1909,7 +1909,7 @@ defmodule BroadwayTest do
 
       refute_receive {:handle_message_called, %Broadway.Message{data: :message_during_cancel}}
 
-      send(get_rate_limiter(broadway_name), {:reset_limit, _allowed = 2})
+      send(get_rate_limiter(broadway_name), :reset_limit)
 
       assert_receive {:handle_message_called, %Broadway.Message{data: :message_during_cancel}}
     end


### PR DESCRIPTION
Initial work on rate limiting producers. I think that this is the right direction, butI might be wrong so let me know :) Some questions:

  * we should probably limit the size of the buffer where we store messages. Should we have `:buffer_keep` and `:buffer_size` like GenStage has?

  * right now, the rate limiting is per producer. At work, we need rate limiting per pipeline, that is, the total number of messages consumed needs to be under a certain rate. A solution can be to just have each producer have a rate limit of `total_rate_limit / number_of_producers` per second. This practically works but might not be optimal because if a producer can produce a lot while another producer is slow, the fast producer will be penalized by its own rate limiting instead of sharing the rate limiting and improving throughput. Another thought is that Broadway doesn't have correlation between producers and processors, so I don't know if rate limiting per producer is every useful rather than rate limiting globally. What are your thoughts on this?