### PR TITLE
Add support for redirecting messages

### DIFF
--- a/lib/broadway/line_producer.ex
+++ b/lib/broadway/line_producer.ex
@@ -1,0 +1,70 @@
+defmodule Broadway.LineProducer do
+  @moduledoc """
+  A GenStage producer that receives one message at a time
+  from an upstream pipeline.
+
+  In theatre, a Line Producer manages the budget of a
+  production, and generally only works on one production
+  at a time. `Broadway.LineProducer` plays a similar role,
+  as it budgets the time to dispatch messages redirected
+  to its pipeline, and it only accepts one new message at a
+  time.
+
+  This implementation will keep messages in an internal
+  queue until there is demand, leading to client timeouts
+  for slow consumers.
+
+  You can use the mental picture of a line of people
+  (messages) waiting for their turn to be dispatched.
+  Messages enter at the rear (tail) of the line and are
+  dispatched from the front (head) of the line.
+
+  See the "Chaining Pipelines" section in the `Broadway`
+  module documentation for more information.
+  """
+  use GenStage
+  alias Broadway.Producer
+
+  @behaviour Producer
+
+  def start_link(opts \\ []) do
+    {server_opts, opts} = Keyword.split(opts, [:name])
+    GenStage.start_link(__MODULE__, opts, server_opts)
+  end
+
+  @doc """
+  Sends a `Broadway.Message` and returns only after the
+  message is dispatched.
+  """
+  @spec dispatch(GenServer.server(), Message.t(), timeout :: GenServer.timeout()) :: :ok
+  def dispatch(line_producer, message, timeout \\ 5000) do
+    GenStage.call(line_producer, {__MODULE__, :dispatch, message}, timeout)
+  end
+
+  ## Callbacks
+
+  @impl true
+  def init(_opts) do
+    {:producer, {:queue.new(), 0}}
+  end
+
+  @impl true
+  def handle_call({__MODULE__, :dispatch, message}, from, {queue, demand}) do
+    dispatch_messages(:queue.in({from, message}, queue), demand, [])
+  end
+
+  @impl true
+  def handle_demand(incoming_demand, {queue, demand}) do
+    dispatch_messages(queue, incoming_demand + demand, [])
+  end
+
+  defp dispatch_messages(queue, demand, messages) do
+    with d when d > 0 <- demand,
+         {{:value, {from, message}}, queue} <- :queue.out(queue) do
+      GenStage.reply(from, :ok)
+      dispatch_messages(queue, demand - 1, [message | messages])
+    else
+      _ -> {:noreply, Enum.reverse(messages), {queue, demand}}
+    end
+  end
+end

--- a/lib/broadway/redirector.ex
+++ b/lib/broadway/redirector.ex
@@ -1,0 +1,70 @@
+defmodule Broadway.Redirector do
+  # Redirection logic for routing messages to a proceeding pipeline.
+  @moduledoc false
+  alias Broadway.{LineProducer, Message, NoopAcknowledger, Server}
+
+  @spec redirect(
+          server :: GenServer.server(),
+          batch :: [Message.t(), ...],
+          opts :: any
+        ) :: [Message.t(), ...]
+  def redirect(server, messages, opts \\ []) when is_list(messages) and messages != [] do
+    # skip redirecting failed and/or acknowledged messages
+    {redirects, skipped} =
+      Enum.split_with(messages, fn
+        %Message{status: :ok, acknowledger: {acknowledger, _, _}}
+        when acknowledger != NoopAcknowledger ->
+          true
+
+        _ ->
+          false
+      end)
+
+    # dispatch messages to producer stages, returning results and messages
+    for {result, message} <- dispatch_and_return(server, redirects, opts) do
+      case result do
+        {:ok, message} ->
+          # set a no-op acknowledger for the return to `handle_batch/4`
+          %{message | acknowledger: {NoopAcknowledger, _ack_ref = nil, _ack_data = nil}}
+
+        {:exit, reason} ->
+          # failed dispatch fails the message
+          Message.failed(message, reason)
+      end
+    end ++ skipped
+  end
+
+  @doc false
+  @spec dispatch(Message.t(), GenServer.server(), GenServer.timeout()) :: Message.t() | no_return
+  def dispatch(message, server, timeout) do
+    producer = Enum.random(Server.producer_names(server))
+
+    if pid = Process.whereis(producer) do
+      _ =
+        LineProducer.dispatch(
+          pid,
+          # reset the batcher values before dispatching
+          %{message | batcher: :default, batch_key: :default},
+          timeout
+        )
+
+      message
+    else
+      Message.failed(message, {:redirect, server})
+    end
+  end
+
+  defp dispatch_and_return(server, messages, opts) do
+    timeout = opts[:timeout] || 5000
+    ordered = opts[:ordered] || false
+
+    messages
+    |> Task.async_stream(__MODULE__, :dispatch, [server, timeout],
+      max_concurrency: length(Server.producer_names(server)),
+      on_timeout: :kill_task,
+      ordered: ordered,
+      timeout: :infinity
+    )
+    |> Enum.zip(messages)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -62,6 +62,7 @@ defmodule Broadway.MixProject do
         ],
         Producers: [
           Broadway.DummyProducer,
+          Broadway.LineProducer,
           Broadway.TermStorage
         ]
       ]


### PR DESCRIPTION
Initial work on a `redirect/2` function to dispatch messages from `handle_batch/4` in PipelineA to `handle_message/3` in PipelineB.  Related to the discussion in #39 

I feel like this is _close_ to where it needs to be, but the Consumer still fails the entire batch when a single dispatch times out, which isn't exactly what I was going for.

Opening a draft PR to get feedback on the current progress.  Thanks!