### PR TITLE
Fix handle failed messages

### DIFF
--- a/lib/broadway/consumer.ex
+++ b/lib/broadway/consumer.ex
@@ -43,7 +43,7 @@ defmodule Broadway.Consumer do
         failed_messages,
         state.module,
         state.context,
-        size
+        length(failed_messages)
       )
 
     if returned != size do


### PR DESCRIPTION
When reporting failed messages the consumer uses the `size` from `BatchInfo` instead of the number of failed messages.

This causes a runtime error when you implement `handle_failed/2` callback and only some messages in the batch fails.