### PR TITLE
Use last release 0.5.0 on README [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Add `:broadway` to the list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:broadway, "~> 0.4.0"}
+    {:broadway, "~> 0.5.0"}
   ]
 end
 ```


### PR DESCRIPTION
Just update last release on readme https://github.com/plataformatec/broadway/releases/tag/v0.5.0