### PR TITLE
Initial attempt at telemetry integration

### DIFF
--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -58,7 +58,40 @@ defmodule Broadway do
       number of requests. See the ":rate_limiting" option for producers in
       `start_link/2`.
 
-    * Statistics/Metrics (TODO)
+    * Statistics/Metrics: Broadway leverages the `:telemetry` library for
+      instrumentation. Broadway currently exposes the following telemetry
+      events:
+
+      * `[:broadway, :batcher, :start]` - Dispatched by Broadway.Consumer before
+        your `handle_batch/4` callback is invoked
+        * Measurement: `%{time: System.monotonic_time}`
+        * Metadata: `%{module: module, batch_info: Broadway.BatchInfo.t}`
+
+      * `[:broadway, :batcher, :stop]` - Dispatched by Broadway.Consumer after your
+        `handle_batch/4` callback has returned
+        * Measurement: `%{duration: native_time}`
+        * Metadata: `%{module: module, batch_info: Broadway.BatchInfo.t}`
+
+      * `[:broadway, :batcher, :error]` - Dispatched by Broadway.Consumer when your
+        `handle_batch/4` callback raises an error
+        * Measurement: `%{duration: native_time}`
+        * Metadata: `%{module: module, batch_info: Broadway.BatchInfo.t, error: Exception.t()}`
+
+      * `[:broadway, :processor, :start]` - Dispatched by Broadway.Processor before
+         your `handle_message/3` callback is invoked
+        * Measurement: `%{time: System.monotonic_time}`
+        * Metadata: `%{module: module, processor_key: atom}`
+
+      * `[:broadway, :processor, :stop]` -  Dispatched by Broadway.Processor after
+        your `handle_message/3` callback has returned
+        * Measurement: `%{duration: native_time}`
+        * Metadata: `%{module: module, processor_key: atom}`
+
+      * `[:broadway, :processor, :error]` -  Dispatched by Broadway.Processor when
+        your `handle_message/3` callback raises an error
+        * Measurement: `%{duration: native_time}`
+        * Metadata: `%{module: module, processor_key: atom, error: Exception.t()}`
+
     * Back-off (TODO)
 
   ## The Broadway Behaviour

--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -414,13 +414,13 @@ defmodule Broadway do
       * Metadata:
 
         ```
-          %{
-            name: atom,
-            message: Broadway.Message.t,
-            module: module,
-            processor: atom,
-            error: Exception.t
-          }
+        %{
+          name: atom,
+          message: Broadway.Message.t,
+          module: module,
+          processor: atom,
+          error: Exception.t
+        }
         ```
 
     * `[:broadway, :consumer, :start]` - Dispatched by a Broadway consumer before your
@@ -430,12 +430,12 @@ defmodule Broadway do
       * Metadata:
 
         ```
-          %{
-            name: atom,
-            messages: [Broadway.Message.t],
-            module: module,
-            batch_info: Broadway.BatchInfo.t
-          }
+        %{
+          name: atom,
+          messages: [Broadway.Message.t],
+          module: module,
+          batch_info: Broadway.BatchInfo.t
+        }
         ```
 
     * `[:broadway, :consumer, :stop]` - Dispatched by a Broadway consumer after your
@@ -445,12 +445,12 @@ defmodule Broadway do
       * Metadata:
 
         ```
-          %{
-            name: atom,
-            messages: [Broadway.Message.t],
-            module: module,
-            batch_info: Broadway.BatchInfo.t
-          }
+        %{
+          name: atom,
+          messages: [Broadway.Message.t],
+          module: module,
+          batch_info: Broadway.BatchInfo.t
+        }
         ```
 
     * `[:broadway, :consumer, :error]` - Dispatched by a Broadway consumer if your
@@ -460,13 +460,13 @@ defmodule Broadway do
       * Metadata:
 
         ```
-          %{
-            name: atom,
-            module: module(),
-            messages: [Broadway.Message.t],
-            batch_info: Broadway.BatchInfo.t,
-            error: Exception.t
-          }
+        %{
+          name: atom,
+          module: module(),
+          messages: [Broadway.Message.t],
+          batch_info: Broadway.BatchInfo.t,
+          error: Exception.t
+        }
         ```
 
     * `[:broadway, :batcher, :start]` - Dispatched by a Broadway batcher before

--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -399,50 +399,81 @@ defmodule Broadway do
       `c:handle_message/3` callback is invoked
 
       * Measurement: `%{time: System.monotonic_time}`
-      * Metadata: `%{name: atom, messages: [Broadway.Message.t]}`
+      * Metadata: `%{name: atom, message: t:Broadway.Message.t, module: module, processor: atom}`
 
     * `[:broadway, :processor, :stop]` -  Dispatched by a Broadway processor after
       your `c:handle_message/3` callback has returned
 
       * Measurement: `%{time: System.monotonic_time, duration: native_time}`
+      * Metadata: `%{name: atom, message: t:Broadway.Message.t, module: module, processor: atom}`
 
+    * `[:broadway, :processor, :error]` -  Dispatched by a Broadway processor if
+      your `c:handle_message/3` callback encounters an error
+
+      * Measurement: `%{time: System.monotonic_time, duration: native_time}`
       * Metadata:
 
         ```
-        %{
-          name: atom,
-          successful_messages_to_ack: [Broadway.Message.t],
-          successful_messages_to_forward: [Broadway.Message.t],
-          failed_messages: [Broadway.Message.t]
-        }
+          %{
+            name: atom,
+            message: Broadway.Message.t,
+            module: module,
+            processor: atom,
+            error: t:Exception.t
+          }
         ```
 
     * `[:broadway, :consumer, :start]` - Dispatched by a Broadway consumer before your
       `c:handle_batch/4` callback is invoked
 
       * Measurement: `%{time: System.monotonic_time}`
-      * Metadata: `%{name: atom, messages: [Broadway.Message.t]}`
+      * Metadata:
+
+        ```
+          %{
+            name: atom,
+            messages: [t:Broadway.Message.t],
+            module: module,
+            batch_info: t:Broadway.BatchInfo.t
+          }
+        ```
 
     * `[:broadway, :consumer, :stop]` - Dispatched by a Broadway consumer after your
       `c:handle_batch/4` callback has returned
 
       * Measurement: `%{time: System.monotonic_time, duration: native_time}`
-
       * Metadata:
 
         ```
-        %{
-          name: atom,
-          successful_messages: [Broadway.Message.t],
-          failed_messages: [Broadway.Message.t]
-        }
+          %{
+            name: atom,
+            messages: [t:Broadway.Message.t],
+            module: module,
+            batch_info: t:Broadway.BatchInfo.t
+          }
+        ```
+
+    * `[:broadway, :consumer, :error]` - Dispatched by a Broadway consumer if your
+      `c:handle_batch/4` callback encounters an error
+
+      * Measurement: `%{time: System.monotonic_time, duration: native_time}`
+      * Metadata:
+
+        ```
+          %{
+            name: atom,
+            module: module(),
+            messages: [t:Broadway.Message.t],
+            batch_info: t:Broadway.BatchInfo.t,
+            error: t:Exception.t
+          }
         ```
 
     * `[:broadway, :batcher, :start]` - Dispatched by a Broadway batcher before
       handling events
 
       * Measurement: `%{time: System.monotonic_time}`
-      * Metadata: `%{name: atom, events: [{Broadway.Message.t}]}`
+      * Metadata: `%{name: atom, events: [{t:Broadway.Message.t}]}`
 
     * `[:broadway, :batcher, :stop]` - Dispatched by a Broadway batcher after
       handling events

--- a/lib/broadway.ex
+++ b/lib/broadway.ex
@@ -399,13 +399,13 @@ defmodule Broadway do
       `c:handle_message/3` callback is invoked
 
       * Measurement: `%{time: System.monotonic_time}`
-      * Metadata: `%{name: atom, message: t:Broadway.Message.t, module: module, processor: atom}`
+      * Metadata: `%{name: atom, message: Broadway.Message.t, module: module, processor: atom}`
 
     * `[:broadway, :processor, :stop]` -  Dispatched by a Broadway processor after
       your `c:handle_message/3` callback has returned
 
       * Measurement: `%{time: System.monotonic_time, duration: native_time}`
-      * Metadata: `%{name: atom, message: t:Broadway.Message.t, module: module, processor: atom}`
+      * Metadata: `%{name: atom, message: Broadway.Message.t, module: module, processor: atom}`
 
     * `[:broadway, :processor, :error]` -  Dispatched by a Broadway processor if
       your `c:handle_message/3` callback encounters an error
@@ -419,7 +419,7 @@ defmodule Broadway do
             message: Broadway.Message.t,
             module: module,
             processor: atom,
-            error: t:Exception.t
+            error: Exception.t
           }
         ```
 
@@ -432,9 +432,9 @@ defmodule Broadway do
         ```
           %{
             name: atom,
-            messages: [t:Broadway.Message.t],
+            messages: [Broadway.Message.t],
             module: module,
-            batch_info: t:Broadway.BatchInfo.t
+            batch_info: Broadway.BatchInfo.t
           }
         ```
 
@@ -447,9 +447,9 @@ defmodule Broadway do
         ```
           %{
             name: atom,
-            messages: [t:Broadway.Message.t],
+            messages: [Broadway.Message.t],
             module: module,
-            batch_info: t:Broadway.BatchInfo.t
+            batch_info: Broadway.BatchInfo.t
           }
         ```
 
@@ -463,9 +463,9 @@ defmodule Broadway do
           %{
             name: atom,
             module: module(),
-            messages: [t:Broadway.Message.t],
-            batch_info: t:Broadway.BatchInfo.t,
-            error: t:Exception.t
+            messages: [Broadway.Message.t],
+            batch_info: Broadway.BatchInfo.t,
+            error: Exception.t
           }
         ```
 
@@ -473,7 +473,7 @@ defmodule Broadway do
       handling events
 
       * Measurement: `%{time: System.monotonic_time}`
-      * Metadata: `%{name: atom, events: [{t:Broadway.Message.t}]}`
+      * Metadata: `%{name: atom, events: [{Broadway.Message.t}]}`
 
     * `[:broadway, :batcher, :stop]` - Dispatched by a Broadway batcher after
       handling events

--- a/lib/broadway/batcher.ex
+++ b/lib/broadway/batcher.ex
@@ -65,7 +65,7 @@ defmodule Broadway.Batcher do
 
   defp emit_stop_event(name, start_time) do
     stop_time = System.monotonic_time()
-    measurements = %{duration: stop_time - start_time}
+    measurements = %{time: stop_time, duration: stop_time - start_time}
     metadata = %{name: name}
 
     :telemetry.execute([:broadway, :batcher, :stop], measurements, metadata)

--- a/lib/broadway/batcher.ex
+++ b/lib/broadway/batcher.ex
@@ -52,19 +52,22 @@ defmodule Broadway.Batcher do
     emit_start_event(state.name, start_time, events)
     batches = handle_events_per_batch_key(events, [], state)
     emit_stop_event(state.name, start_time)
+
     {:noreply, batches, state}
   end
 
   defp emit_start_event(name, start_time, events) do
     metadata = %{name: name, events: events}
     measurements = %{time: start_time}
+
     :telemetry.execute([:broadway, :batcher, :start], measurements, metadata)
   end
 
   defp emit_stop_event(name, start_time) do
     stop_time = System.monotonic_time()
-    measurements = %{time: stop_time, duration: stop_time - start_time}
+    measurements = %{duration: stop_time - start_time}
     metadata = %{name: name}
+
     :telemetry.execute([:broadway, :batcher, :stop], measurements, metadata)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -27,6 +27,7 @@ defmodule Broadway.MixProject do
   defp deps do
     [
       {:gen_stage, "~> 0.14"},
+      {:telemetry, "~> 0.4.1"},
       {:ex_doc, ">= 0.19.0", only: :docs}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -5,4 +5,5 @@
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
+  "telemetry": {:hex, :telemetry, "0.4.1", "ae2718484892448a24470e6aa341bc847c3277bfb8d4e9289f7474d752c09c7f", [:rebar3], [], "hexpm"},
 }


### PR DESCRIPTION
This PR is an attempt to resolve #3. I took inspiration from Plug and Phoenix in order to make the telemetry events and docs idiomatic. The PR is not yet complete as it requires some tests to validate all of the events are emitted when they are supposed to be, but I wanted to make sure I was on the right track before going through the effort of adding tests for everything.

This PR adds the following events:
```
[:broadway, :processor, :start]
[:broadway, :processor, :stop]
[:broadway, :processor, :error]
[:broadway, :batcher, :start]
[:broadway, :batcher, :stop]
[:broadway, :batcher, :error]
```

I tested my fork out on a personal Broadway project of mine and the code changes look like they work as intended. 

Looking for feedback as to what I should change or add (if more telemetry events are desired).

Thanks!